### PR TITLE
fixing bootstrap two.sided ci argument test

### DIFF
--- a/R/egammaAltCensored.bootstrap.ci.R
+++ b/R/egammaAltCensored.bootstrap.ci.R
@@ -1,6 +1,6 @@
 egammaAltCensored.bootstrap.ci <-
-function (x, censored, censoring.side, est.fcn, ci.type, conf.level, 
-    n.bootstraps, obs.mean) 
+function (x, censored, censoring.side, est.fcn, ci.type, conf.level,
+    n.bootstraps, obs.mean)
 {
     N <- length(x)
     boot.vec <- numeric(n.bootstraps)
@@ -22,22 +22,22 @@ function (x, censored, censoring.side, est.fcn, ci.type, conf.level,
             no.cen.obs.count <- no.cen.obs.count + 1
         }
         else {
-            boot.vec[i] <- do.call(est.fcn, list(x = new.x, censored = new.censored, 
+            boot.vec[i] <- do.call(est.fcn, list(x = new.x, censored = new.censored,
                 censoring.side = censoring.side, ci = FALSE))$parameters["mean"]
         }
     }
     alpha <- 1 - conf.level
-    if (ci.type == "two.sided") 
+    if (ci.type == "two-sided")
         alpha <- alpha/2
-    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec, 
-        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec, 
-        probs = alpha), Inf), upper = c(0, quantile(boot.vec, 
+    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec,
+        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec,
+        probs = alpha), Inf), upper = c(0, quantile(boot.vec,
         probs = conf.level)))
     compute.bca <- length(unique(x.no.cen)) >= 3
     if (compute.bca) {
         za <- qnorm(alpha)
         z0 <- qnorm(sum(boot.vec <= obs.mean)/n.bootstraps)
-        jack.vec <- egammaAltCensored.jackknife(x = x, censored = censored, 
+        jack.vec <- egammaAltCensored.jackknife(x = x, censored = censored,
             censoring.side = censoring.side, est.fcn = est.fcn)
         num <- sum(as.vector(scale(jack.vec, scale = FALSE))^3)
         denom <- 6 * (((length(jack.vec) - 1) * var(jack.vec))^(3/2))
@@ -54,13 +54,13 @@ function (x, censored, censoring.side, est.fcn, ci.type, conf.level,
             c(0, quantile(boot.vec, probs = alpha2))
         })
     }
-    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA, 
+    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA,
         NA), lower = c(NA, Inf), upper = c(-Inf, NA))
     ci.limits <- c(ci.limits.pct, ci.limits.bca)
     names(ci.limits) <- c("Pct.LCL", "Pct.UCL", "BCa.LCL", "BCa.UCL")
-    ret.obj <- list(name = "Confidence", parameter = "mean", 
-        limits = ci.limits, type = ci.type, method = "Bootstrap", 
-        conf.level = conf.level, n.bootstraps = n.bootstraps, 
+    ret.obj <- list(name = "Confidence", parameter = "mean",
+        limits = ci.limits, type = ci.type, method = "Bootstrap",
+        conf.level = conf.level, n.bootstraps = n.bootstraps,
         too.few.obs.count = too.few.obs.count, no.cen.obs.count = no.cen.obs.count)
     oldClass(ret.obj) <- "intervalEstimateCensored"
     ret.obj

--- a/R/elnormAltMultiplyCensored.bootstrap.ci.R
+++ b/R/elnormAltMultiplyCensored.bootstrap.ci.R
@@ -1,6 +1,6 @@
 elnormAltMultiplyCensored.bootstrap.ci <-
-function (x, censored, N, cen.levels, K, c.vec, n.cen, censoring.side, 
-    est.fcn, ci.type, conf.level, n.bootstraps, obs.mean, ...) 
+function (x, censored, N, cen.levels, K, c.vec, n.cen, censoring.side,
+    est.fcn, ci.type, conf.level, n.bootstraps, obs.mean, ...)
 {
     boot.vec <- numeric(n.bootstraps)
     too.few.obs.count <- 0
@@ -25,27 +25,27 @@ function (x, censored, N, cen.levels, K, c.vec, n.cen, censoring.side,
             new.c.vec <- table(new.x.cen)
             new.cen.levels <- sort(unique(new.x.cen))
             new.K <- length(new.cen.levels)
-            boot.vec[i] <- do.call(est.fcn, list(x = new.x, censored = new.censored, 
-                N = N, cen.levels = new.cen.levels, K = new.K, 
-                c.vec = new.c.vec, n.cen = new.n.cen, censoring.side = censoring.side, 
+            boot.vec[i] <- do.call(est.fcn, list(x = new.x, censored = new.censored,
+                N = N, cen.levels = new.cen.levels, K = new.K,
+                c.vec = new.c.vec, n.cen = new.n.cen, censoring.side = censoring.side,
                 ci = FALSE, ...))$parameters[1]
         }
     }
     alpha <- 1 - conf.level
-    if (ci.type == "two.sided") 
+    if (ci.type == "two-sided")
         alpha <- alpha/2
-    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec, 
-        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec, 
-        probs = alpha), Inf), upper = c(0, quantile(boot.vec, 
+    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec,
+        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec,
+        probs = alpha), Inf), upper = c(0, quantile(boot.vec,
         probs = conf.level)))
     compute.bca <- length(unique(x.no.cen)) >= 3
     if (compute.bca) {
         za <- qnorm(alpha)
         z0 <- qnorm(sum(boot.vec <= obs.mean)/n.bootstraps)
-        jack.vec <- elnormAltMultiplyCensored.jackknife(x = x, 
-            censored = censored, N = N, cen.levels = cen.levels, 
-            K = K, c.vec = c.vec, n.cen = n.cen, censoring.side = censoring.side, 
-            est.fcn = est.fcn, ci.type = ci.type, conf.level = conf.level, 
+        jack.vec <- elnormAltMultiplyCensored.jackknife(x = x,
+            censored = censored, N = N, cen.levels = cen.levels,
+            K = K, c.vec = c.vec, n.cen = n.cen, censoring.side = censoring.side,
+            est.fcn = est.fcn, ci.type = ci.type, conf.level = conf.level,
             ...)
         num <- sum(as.vector(scale(jack.vec, scale = FALSE))^3)
         denom <- 6 * (((length(jack.vec) - 1) * var(jack.vec))^(3/2))
@@ -62,13 +62,13 @@ function (x, censored, N, cen.levels, K, c.vec, n.cen, censoring.side,
             c(0, quantile(boot.vec, probs = alpha2))
         })
     }
-    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA, 
+    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA,
         NA), lower = c(NA, Inf), upper = c(0, NA))
     ci.limits <- c(ci.limits.pct, ci.limits.bca)
     names(ci.limits) <- c("Pct.LCL", "Pct.UCL", "BCa.LCL", "BCa.UCL")
-    ret.obj <- list(name = "Confidence", parameter = "mean", 
-        limits = ci.limits, type = ci.type, method = "Bootstrap", 
-        conf.level = conf.level, n.bootstraps = n.bootstraps, 
+    ret.obj <- list(name = "Confidence", parameter = "mean",
+        limits = ci.limits, type = ci.type, method = "Bootstrap",
+        conf.level = conf.level, n.bootstraps = n.bootstraps,
         too.few.obs.count = too.few.obs.count, no.cen.obs.count = no.cen.obs.count)
     oldClass(ret.obj) <- "intervalEstimateCensored"
     ret.obj

--- a/R/elnormAltSinglyCensored.bootstrap.ci.R
+++ b/R/elnormAltSinglyCensored.bootstrap.ci.R
@@ -1,6 +1,6 @@
 elnormAltSinglyCensored.bootstrap.ci <-
-function (x, censored, N, T1, censoring.side, est.fcn, ci.type, 
-    conf.level, n.bootstraps, obs.mean, ...) 
+function (x, censored, N, T1, censoring.side, est.fcn, ci.type,
+    conf.level, n.bootstraps, obs.mean, ...)
 {
     boot.vec <- numeric(n.bootstraps)
     too.few.obs.count <- 0
@@ -20,24 +20,24 @@ function (x, censored, N, T1, censoring.side, est.fcn, ci.type,
             boot.vec[i] <- elnormAlt(new.x)$parameters[1]
             no.cen.obs.count <- no.cen.obs.count + 1
         }
-        else boot.vec[i] <- do.call(est.fcn, list(x = new.x, 
-            censored = new.censored, N = N, T1 = T1, n.cen = new.n.cen, 
+        else boot.vec[i] <- do.call(est.fcn, list(x = new.x,
+            censored = new.censored, N = N, T1 = T1, n.cen = new.n.cen,
             censoring.side = censoring.side, ci = FALSE, ...))$parameters[1]
     }
     alpha <- 1 - conf.level
-    if (ci.type == "two.sided") 
+    if (ci.type == "two-sided")
         alpha <- alpha/2
-    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec, 
-        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec, 
-        probs = alpha), Inf), upper = c(0, quantile(boot.vec, 
+    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec,
+        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec,
+        probs = alpha), Inf), upper = c(0, quantile(boot.vec,
         probs = conf.level)))
     compute.bca <- length(unique(x.no.cen)) >= 3
     if (compute.bca) {
         za <- qnorm(alpha)
         z0 <- qnorm(sum(boot.vec <= obs.mean)/n.bootstraps)
-        jack.vec <- elnormAltSinglyCensored.jackknife(x = x, 
-            censored = censored, N = N, T1 = T1, censoring.side = censoring.side, 
-            est.fcn = est.fcn, ci.type = ci.type, conf.level = conf.level, 
+        jack.vec <- elnormAltSinglyCensored.jackknife(x = x,
+            censored = censored, N = N, T1 = T1, censoring.side = censoring.side,
+            est.fcn = est.fcn, ci.type = ci.type, conf.level = conf.level,
             ...)
         num <- sum(as.vector(scale(jack.vec, scale = FALSE))^3)
         denom <- 6 * (((length(jack.vec) - 1) * var(jack.vec))^(3/2))
@@ -54,13 +54,13 @@ function (x, censored, N, T1, censoring.side, est.fcn, ci.type,
             c(0, quantile(boot.vec, probs = alpha2))
         })
     }
-    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA, 
+    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA,
         NA), lower = c(NA, Inf), upper = c(-Inf, NA))
     ci.limits <- c(ci.limits.pct, ci.limits.bca)
     names(ci.limits) <- c("Pct.LCL", "Pct.UCL", "BCa.LCL", "BCa.UCL")
-    ret.obj <- list(name = "Confidence", parameter = "mean", 
-        limits = ci.limits, type = ci.type, method = "Bootstrap", 
-        conf.level = conf.level, n.bootstraps = n.bootstraps, 
+    ret.obj <- list(name = "Confidence", parameter = "mean",
+        limits = ci.limits, type = ci.type, method = "Bootstrap",
+        conf.level = conf.level, n.bootstraps = n.bootstraps,
         too.few.obs.count = too.few.obs.count, no.cen.obs.count = no.cen.obs.count)
     oldClass(ret.obj) <- "intervalEstimateCensored"
     ret.obj

--- a/R/enormMultiplyCensored.bootstrap.ci.R
+++ b/R/enormMultiplyCensored.bootstrap.ci.R
@@ -1,6 +1,6 @@
 enormMultiplyCensored.bootstrap.ci <-
-function (x, censored, N, cen.levels, K, c.vec, n.cen, censoring.side, 
-    est.fcn, ci.type, conf.level, n.bootstraps, obs.mean, ...) 
+function (x, censored, N, cen.levels, K, c.vec, n.cen, censoring.side,
+    est.fcn, ci.type, conf.level, n.bootstraps, obs.mean, ...)
 {
     boot.vec <- numeric(n.bootstraps)
     too.few.obs.count <- 0
@@ -25,26 +25,26 @@ function (x, censored, N, cen.levels, K, c.vec, n.cen, censoring.side,
             new.c.vec <- table(new.x.cen)
             new.cen.levels <- sort(unique(new.x.cen))
             new.K <- length(new.cen.levels)
-            boot.vec[i] <- do.call(est.fcn, list(x = new.x, censored = new.censored, 
-                N = N, cen.levels = new.cen.levels, K = new.K, 
-                c.vec = new.c.vec, n.cen = new.n.cen, censoring.side = censoring.side, 
+            boot.vec[i] <- do.call(est.fcn, list(x = new.x, censored = new.censored,
+                N = N, cen.levels = new.cen.levels, K = new.K,
+                c.vec = new.c.vec, n.cen = new.n.cen, censoring.side = censoring.side,
                 ci = FALSE, ...))$parameters[1]
         }
     }
     alpha <- 1 - conf.level
-    if (ci.type == "two.sided") 
+    if (ci.type == "two-sided")
         alpha <- alpha/2
-    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec, 
-        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec, 
-        probs = alpha), Inf), upper = c(-Inf, quantile(boot.vec, 
+    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec,
+        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec,
+        probs = alpha), Inf), upper = c(-Inf, quantile(boot.vec,
         probs = conf.level)))
     compute.bca <- length(unique(x.no.cen)) >= 3
     if (compute.bca) {
         za <- qnorm(alpha)
         z0 <- qnorm(sum(boot.vec <= obs.mean)/n.bootstraps)
-        jack.vec <- enormMultiplyCensored.jackknife(x = x, censored = censored, 
-            N = N, cen.levels = cen.levels, K = K, c.vec = c.vec, 
-            n.cen = n.cen, censoring.side = censoring.side, est.fcn = est.fcn, 
+        jack.vec <- enormMultiplyCensored.jackknife(x = x, censored = censored,
+            N = N, cen.levels = cen.levels, K = K, c.vec = c.vec,
+            n.cen = n.cen, censoring.side = censoring.side, est.fcn = est.fcn,
             ci.type = ci.type, conf.level = conf.level, ...)
         num <- sum(as.vector(scale(jack.vec, scale = FALSE))^3)
         denom <- 6 * (((length(jack.vec) - 1) * var(jack.vec))^(3/2))
@@ -61,13 +61,13 @@ function (x, censored, N, cen.levels, K, c.vec, n.cen, censoring.side,
             c(-Inf, quantile(boot.vec, probs = alpha2))
         })
     }
-    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA, 
+    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA,
         NA), lower = c(NA, Inf), upper = c(-Inf, NA))
     ci.limits <- c(ci.limits.pct, ci.limits.bca)
     names(ci.limits) <- c("Pct.LCL", "Pct.UCL", "BCa.LCL", "BCa.UCL")
-    ret.obj <- list(name = "Confidence", parameter = "mean", 
-        limits = ci.limits, type = ci.type, method = "Bootstrap", 
-        conf.level = conf.level, n.bootstraps = n.bootstraps, 
+    ret.obj <- list(name = "Confidence", parameter = "mean",
+        limits = ci.limits, type = ci.type, method = "Bootstrap",
+        conf.level = conf.level, n.bootstraps = n.bootstraps,
         too.few.obs.count = too.few.obs.count, no.cen.obs.count = no.cen.obs.count)
     oldClass(ret.obj) <- "intervalEstimateCensored"
     ret.obj

--- a/R/enormSinglyCensored.bootstrap.ci.R
+++ b/R/enormSinglyCensored.bootstrap.ci.R
@@ -1,6 +1,6 @@
 enormSinglyCensored.bootstrap.ci <-
-function (x, censored, N, T1, censoring.side, est.fcn, ci.type, 
-    conf.level, n.bootstraps, obs.mean, ...) 
+function (x, censored, N, T1, censoring.side, est.fcn, ci.type,
+    conf.level, n.bootstraps, obs.mean, ...)
 {
     boot.vec <- numeric(n.bootstraps)
     too.few.obs.count <- 0
@@ -20,24 +20,24 @@ function (x, censored, N, T1, censoring.side, est.fcn, ci.type,
             boot.vec[i] <- mean(new.x)
             no.cen.obs.count <- no.cen.obs.count + 1
         }
-        else boot.vec[i] <- do.call(est.fcn, list(x = new.x, 
-            censored = new.censored, N = N, T1 = T1, n.cen = new.n.cen, 
+        else boot.vec[i] <- do.call(est.fcn, list(x = new.x,
+            censored = new.censored, N = N, T1 = T1, n.cen = new.n.cen,
             censoring.side, ci = FALSE, ...))$parameters[1]
     }
     alpha <- 1 - conf.level
-    if (ci.type == "two.sided") 
+    if (ci.type == "two-sided")
         alpha <- alpha/2
-    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec, 
-        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec, 
-        probs = alpha), Inf), upper = c(-Inf, quantile(boot.vec, 
+    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec,
+        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec,
+        probs = alpha), Inf), upper = c(-Inf, quantile(boot.vec,
         probs = conf.level)))
     compute.bca <- length(unique(x.no.cen)) >= 3
     if (compute.bca) {
         za <- qnorm(alpha)
         z0 <- qnorm(sum(boot.vec <= obs.mean)/n.bootstraps)
-        jack.vec <- enormSinglyCensored.jackknife(x = x, censored = censored, 
-            N = N, T1 = T1, censoring.side = censoring.side, 
-            est.fcn = est.fcn, ci.type = ci.type, conf.level = conf.level, 
+        jack.vec <- enormSinglyCensored.jackknife(x = x, censored = censored,
+            N = N, T1 = T1, censoring.side = censoring.side,
+            est.fcn = est.fcn, ci.type = ci.type, conf.level = conf.level,
             ...)
         num <- sum(as.vector(scale(jack.vec, scale = FALSE))^3)
         denom <- 6 * (((length(jack.vec) - 1) * var(jack.vec))^(3/2))
@@ -54,13 +54,13 @@ function (x, censored, N, T1, censoring.side, est.fcn, ci.type,
             c(-Inf, quantile(boot.vec, probs = alpha2))
         })
     }
-    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA, 
+    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA,
         NA), lower = c(NA, Inf), upper = c(-Inf, NA))
     ci.limits <- c(ci.limits.pct, ci.limits.bca)
     names(ci.limits) <- c("Pct.LCL", "Pct.UCL", "BCa.LCL", "BCa.UCL")
-    ret.obj <- list(name = "Confidence", parameter = "mean", 
-        limits = ci.limits, type = ci.type, method = "Bootstrap", 
-        conf.level = conf.level, n.bootstraps = n.bootstraps, 
+    ret.obj <- list(name = "Confidence", parameter = "mean",
+        limits = ci.limits, type = ci.type, method = "Bootstrap",
+        conf.level = conf.level, n.bootstraps = n.bootstraps,
         too.few.obs.count = too.few.obs.count, no.cen.obs.count = no.cen.obs.count)
     oldClass(ret.obj) <- "intervalEstimateCensored"
     ret.obj

--- a/R/enparCensored.bootstrap.ci.R
+++ b/R/enparCensored.bootstrap.ci.R
@@ -1,7 +1,7 @@
 enparCensored.bootstrap.ci <-
-function (x, censored, censoring.side, correct.se, left.censored.min, 
-    right.censored.max, est.fcn, ci.type, conf.level, n.bootstraps, 
-    obs.mean, obs.se.mean) 
+function (x, censored, censoring.side, correct.se, left.censored.min,
+    right.censored.max, est.fcn, ci.type, conf.level, n.bootstraps,
+    obs.mean, obs.se.mean)
 {
     N <- length(x)
     boot.vec.mean <- numeric(n.bootstraps)
@@ -26,9 +26,9 @@ function (x, censored, censoring.side, correct.se, left.censored.min,
             no.cen.obs.count <- no.cen.obs.count + 1
         }
         else {
-            params <- do.call(est.fcn, list(x = new.x, censored = new.censored, 
-                censoring.side = censoring.side, correct.se = correct.se, 
-                left.censored.min = left.censored.min, right.censored.max = right.censored.max, 
+            params <- do.call(est.fcn, list(x = new.x, censored = new.censored,
+                censoring.side = censoring.side, correct.se = correct.se,
+                left.censored.min = left.censored.min, right.censored.max = right.censored.max,
                 ci = FALSE))$parameters
             mu.hat <- params["mean"]
             boot.vec.mean[i] <- mu.hat
@@ -36,19 +36,19 @@ function (x, censored, censoring.side, correct.se, left.censored.min,
         }
     }
     alpha <- 1 - conf.level
-    if (ci.type == "two.sided") 
+    if (ci.type == "two-sided")
         alpha <- alpha/2
-    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec.mean, 
-        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec.mean, 
-        probs = alpha), Inf), upper = c(0, quantile(boot.vec.mean, 
+    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec.mean,
+        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec.mean,
+        probs = alpha), Inf), upper = c(0, quantile(boot.vec.mean,
         probs = conf.level)))
     compute.bca <- length(unique(x.no.cen)) >= 3
     if (compute.bca) {
         za <- qnorm(alpha)
         z0 <- qnorm(sum(boot.vec.mean <= obs.mean)/n.bootstraps)
-        jack.vec <- enparCensored.jackknife(x = x, censored = censored, 
-            censoring.side = censoring.side, correct.se = correct.se, 
-            left.censored.min = left.censored.min, right.censored.max = right.censored.max, 
+        jack.vec <- enparCensored.jackknife(x = x, censored = censored,
+            censoring.side = censoring.side, correct.se = correct.se,
+            left.censored.min = left.censored.min, right.censored.max = right.censored.max,
             est.fcn = est.fcn)
         num <- sum(as.vector(scale(jack.vec, scale = FALSE))^3)
         denom <- 6 * (((length(jack.vec) - 1) * var(jack.vec))^(3/2))
@@ -65,12 +65,12 @@ function (x, censored, censoring.side, correct.se, left.censored.min,
             c(0, quantile(boot.vec.mean, probs = alpha2))
         })
     }
-    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA, 
+    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA,
         NA), lower = c(NA, Inf), upper = c(0, NA))
     ci.limits.t <- switch(ci.type, `two-sided` = {
-        t.quantiles <- quantile(boot.vec.t, probs = c(1 - alpha, 
+        t.quantiles <- quantile(boot.vec.t, probs = c(1 - alpha,
             alpha))
-        c(obs.mean - t.quantiles[1] * obs.se.mean, obs.mean - 
+        c(obs.mean - t.quantiles[1] * obs.se.mean, obs.mean -
             t.quantiles[2] * obs.se.mean)
     }, lower = {
         t.quantiles <- quantile(boot.vec.t, probs = 1 - alpha)
@@ -80,11 +80,11 @@ function (x, censored, censoring.side, correct.se, left.censored.min,
         c(0, obs.mean - t.quantiles * obs.se.mean)
     })
     ci.limits <- c(ci.limits.pct, ci.limits.bca, ci.limits.t)
-    names(ci.limits) <- c("Pct.LCL", "Pct.UCL", "BCa.LCL", "BCa.UCL", 
+    names(ci.limits) <- c("Pct.LCL", "Pct.UCL", "BCa.LCL", "BCa.UCL",
         "t.LCL", "t.UCL")
-    ret.obj <- list(name = "Confidence", parameter = "mean", 
-        limits = ci.limits, type = ci.type, method = "Bootstrap", 
-        conf.level = conf.level, sample.size = N, n.bootstraps = n.bootstraps, 
+    ret.obj <- list(name = "Confidence", parameter = "mean",
+        limits = ci.limits, type = ci.type, method = "Bootstrap",
+        conf.level = conf.level, sample.size = N, n.bootstraps = n.bootstraps,
         too.few.obs.count = too.few.obs.count, no.cen.obs.count = no.cen.obs.count)
     oldClass(ret.obj) <- "intervalEstimateCensored"
     ret.obj

--- a/R/epoisMultiplyCensored.bootstrap.ci.R
+++ b/R/epoisMultiplyCensored.bootstrap.ci.R
@@ -1,6 +1,6 @@
 epoisMultiplyCensored.bootstrap.ci <-
-function (x, censored, censoring.side, est.fcn, ci.type, conf.level, 
-    n.bootstraps, obs.lambda) 
+function (x, censored, censoring.side, est.fcn, ci.type, conf.level,
+    n.bootstraps, obs.lambda)
 {
     N <- length(x)
     boot.vec <- numeric(n.bootstraps)
@@ -21,22 +21,22 @@ function (x, censored, censoring.side, est.fcn, ci.type, conf.level,
             boot.vec[i] <- mean(new.x)
             no.cen.obs.count <- no.cen.obs.count + 1
         }
-        else boot.vec[i] <- do.call(est.fcn, list(x = new.x, 
+        else boot.vec[i] <- do.call(est.fcn, list(x = new.x,
             censored = new.censored, censoring.side, ci = FALSE))$parameters[1]
     }
     alpha <- 1 - conf.level
-    if (ci.type == "two.sided") 
+    if (ci.type == "two-sided")
         alpha <- alpha/2
-    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec, 
-        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec, 
-        probs = alpha), Inf), upper = c(0, quantile(boot.vec, 
+    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec,
+        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec,
+        probs = alpha), Inf), upper = c(0, quantile(boot.vec,
         probs = conf.level)))
     compute.bca <- length(unique(x.no.cen)) >= 3
     if (compute.bca) {
         za <- qnorm(alpha)
         z0 <- qnorm(sum(boot.vec <= obs.lambda)/n.bootstraps)
-        jack.vec <- epoisCensored.jackknife(x = x, censored = censored, 
-            censoring.side = censoring.side, est.fcn = est.fcn, 
+        jack.vec <- epoisCensored.jackknife(x = x, censored = censored,
+            censoring.side = censoring.side, est.fcn = est.fcn,
             ci.type = ci.type, conf.level = conf.level)
         num <- sum(as.vector(scale(jack.vec, scale = FALSE))^3)
         denom <- 6 * (((length(jack.vec) - 1) * var(jack.vec))^(3/2))
@@ -53,13 +53,13 @@ function (x, censored, censoring.side, est.fcn, ci.type, conf.level,
             c(0, quantile(boot.vec, probs = alpha2))
         })
     }
-    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA, 
+    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA,
         NA), lower = c(NA, Inf), upper = c(0, NA))
     ci.limits <- c(ci.limits.pct, ci.limits.bca)
     names(ci.limits) <- c("Pct.LCL", "Pct.UCL", "BCa.LCL", "BCa.UCL")
-    ret.obj <- list(name = "Confidence", parameter = "lambda", 
-        limits = ci.limits, type = ci.type, method = "Bootstrap", 
-        conf.level = conf.level, n.bootstraps = n.bootstraps, 
+    ret.obj <- list(name = "Confidence", parameter = "lambda",
+        limits = ci.limits, type = ci.type, method = "Bootstrap",
+        conf.level = conf.level, n.bootstraps = n.bootstraps,
         too.few.obs.count = too.few.obs.count, no.cen.obs.count = no.cen.obs.count)
     oldClass(ret.obj) <- "intervalEstimateCensored"
     ret.obj

--- a/R/epoisSinglyCensored.bootstrap.ci.R
+++ b/R/epoisSinglyCensored.bootstrap.ci.R
@@ -1,6 +1,6 @@
 epoisSinglyCensored.bootstrap.ci <-
-function (x, censored, censoring.side, est.fcn, ci.type, conf.level, 
-    n.bootstraps, obs.lambda) 
+function (x, censored, censoring.side, est.fcn, ci.type, conf.level,
+    n.bootstraps, obs.lambda)
 {
     N <- length(x)
     boot.vec <- numeric(n.bootstraps)
@@ -21,22 +21,22 @@ function (x, censored, censoring.side, est.fcn, ci.type, conf.level,
             boot.vec[i] <- mean(new.x)
             no.cen.obs.count <- no.cen.obs.count + 1
         }
-        else boot.vec[i] <- do.call(est.fcn, list(x = new.x, 
+        else boot.vec[i] <- do.call(est.fcn, list(x = new.x,
             censored = new.censored, censoring.side, ci = FALSE))$parameters[1]
     }
     alpha <- 1 - conf.level
-    if (ci.type == "two.sided") 
+    if (ci.type == "two-sided")
         alpha <- alpha/2
-    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec, 
-        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec, 
-        probs = alpha), Inf), upper = c(0, quantile(boot.vec, 
+    ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec,
+        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec,
+        probs = alpha), Inf), upper = c(0, quantile(boot.vec,
         probs = conf.level)))
     compute.bca <- length(unique(x.no.cen)) >= 3
     if (compute.bca) {
         za <- qnorm(alpha)
         z0 <- qnorm(sum(boot.vec <= obs.lambda)/n.bootstraps)
-        jack.vec <- epoisCensored.jackknife(x = x, censored = censored, 
-            censoring.side = censoring.side, est.fcn = est.fcn, 
+        jack.vec <- epoisCensored.jackknife(x = x, censored = censored,
+            censoring.side = censoring.side, est.fcn = est.fcn,
             ci.type = ci.type, conf.level = conf.level)
         num <- sum(as.vector(scale(jack.vec, scale = FALSE))^3)
         denom <- 6 * (((length(jack.vec) - 1) * var(jack.vec))^(3/2))
@@ -53,13 +53,13 @@ function (x, censored, censoring.side, est.fcn, ci.type, conf.level,
             c(0, quantile(boot.vec, probs = alpha2))
         })
     }
-    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA, 
+    else ci.limits.bca <- switch(ci.type, `two-sided` = c(NA,
         NA), lower = c(NA, Inf), upper = c(-Inf, NA))
     ci.limits <- c(ci.limits.pct, ci.limits.bca)
     names(ci.limits) <- c("Pct.LCL", "Pct.UCL", "BCa.LCL", "BCa.UCL")
-    ret.obj <- list(name = "Confidence", parameter = "lambda", 
-        limits = ci.limits, type = ci.type, method = "Bootstrap", 
-        conf.level = conf.level, n.bootstraps = n.bootstraps, 
+    ret.obj <- list(name = "Confidence", parameter = "lambda",
+        limits = ci.limits, type = ci.type, method = "Bootstrap",
+        conf.level = conf.level, n.bootstraps = n.bootstraps,
         too.few.obs.count = too.few.obs.count, no.cen.obs.count = no.cen.obs.count)
     oldClass(ret.obj) <- "intervalEstimateCensored"
     ret.obj


### PR DESCRIPTION
Hi - thanks for the great package!  (sorry for multiple pull requests I think I accidently sent the last one to the CRAN repo :()

It seems to me that all of the eight bootstrap ci functions is not correcting for alpha for a two-sided confidence limits. The functions  adjust alpha based on the following test:
 
```{r}
 if (ci.type == "two.sided")
        alpha <- alpha/2
```

Immediately after this is done:

```{r}
 ci.limits.pct <- switch(ci.type, `two-sided` = quantile(boot.vec,
        probs = c(alpha, 1 - alpha)), lower = c(quantile(boot.vec,
        probs = alpha), Inf), upper = c(-Inf, quantile(boot.vec,
        probs = conf.level)))
```

I suggest changing test to 

```{r}
 if (ci.type == "two-sided")
        alpha <- alpha/2
```


Example of problem:

```{r}
library(NADA)
library(EnvStats)

values = c(3,3,3,4:20)
isCensored = c(T,T,T,F,F,F,F,F,F,F,F,F,F,F,F,F,F,F,F,F)

########### Case 1: enparCensored ###########
set.seed(1)
upper95_enparCensored <- enparCensored(values, isCensored, ci = TRUE, ci.type = "upper", 
ci.method = "bootstrap", n=5000, conf = 0.95)
print(upper95_enparCensored$interval$limits) 
#Pct.LCL = 0, Pct.UCL = 12.7

set.seed(1)
twoSided90_enparCensored <- enparCensored(values, isCensored, ci = TRUE, 
ci.type = "two-sided", ci.method = "bootstrap", n=5000, conf = 0.90)
print(twoSided90_enparCensored$interval$limits) 
#Pct.LCL = 9.1, Pct.UCL = 12.25

set.seed(1)
twoSided95_enparCensored <- enparCensored(values, isCensored, ci = TRUE,
 ci.type = "two-sided", ci.method = "bootstrap", n=5000, conf = 0.95)
print(twoSided95_enparCensored$interval$limits) 
#Pct.LCL = 8.7, Pct.UCL = 12.7
```
