### PR TITLE
Update stripChart.default.R - Error when only one datapoint in a group

### DIFF
--- a/R/stripChart.default.R
+++ b/R/stripChart.default.R
@@ -378,6 +378,9 @@ function (x, method = ifelse(paired && paired.lines, "overplot",
             ci.mat[i, c("LCL", "UCL")] <- ci.vec
             ci.mat[i, "Conf.Level"] <- conf.level
         }
+        else{
+          sd.x <- NA
+        }
         if (show.ci) {
             if (n == 2 && paired && paired.lines && i == 1) {
                 if (vertical) {


### PR DESCRIPTION
There was an error that sd.x was not found, if show.ci = T and there is only one datapoint in a group.
Assigning sd.x <- NA for n.vec[i] < 2 works