### PR TITLE
Updates to enparCensored functions

### DIFF
--- a/R/enparCensored.bootstrap.ci.R
+++ b/R/enparCensored.bootstrap.ci.R
@@ -1,5 +1,5 @@
 enparCensored.bootstrap.ci <-
-function (x, censored, censoring.side, correct.se, est.fcn,
+function (x, censored, censoring.side, correct.se, est.fcn, 
   ci.type, conf.level, n.bootstraps, obs.mean, obs.se.mean, seed)
 {
     N <- length(x)
@@ -15,12 +15,13 @@ function (x, censored, censoring.side, correct.se, est.fcn,
         index <- sample(N, replace = TRUE)
         new.x <- x[index]
         new.censored <- censored[index]
-        new.n.cen <- sum(new.censored)
-        if ((N - new.n.cen) < 4) {
+        new.x.no.cen <- new.x[!new.censored]
+        if (length(unique(new.x.no.cen)) < 2) {
             too.few.obs.count <- too.few.obs.count + 1
             i <- i - 1
             next
         }
+        new.n.cen <- sum(new.censored)
         if (new.n.cen == 0) {
             mu.hat <- mean(new.x)
             boot.vec.mean[i] <- mu.hat

--- a/R/enparCensored.km.R
+++ b/R/enparCensored.km.R
@@ -1,6 +1,6 @@
 enparCensored.km <-
-function (x, censored, censoring.side, correct.se, ci, ci.type, 
-    conf.level, pivot.statistic, ci.sample.size)
+function (x, censored, censoring.side, correct.se, ci, ci.type = "two-sided", 
+    conf.level = 0.95, pivot.statistic = "t", ci.sample.size = "Total")
 {
     ppoints.list <- ppointsCensored(x = x, censored = censored, 
         censoring.side = censoring.side, prob.method = "kaplan-meier")


### PR DESCRIPTION
Updated versions of enparCensored.km() and enparCensored.bootstrap.ci().  

1) The previous version of enparCensored.km() needed default values for the arguments ci.type, conf.level, pivot.statistic, and ci.sample.size so that these arguments did not need to be supplied in the case when ci=FALSE.

2) In the previous version of enparCensored.bootstrap.ci(), the test for the number of *unique*  non-censored values was not correct.

fix #39 